### PR TITLE
chore(*): Update comments and help strings for Helm Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helm Classic - The Original Kubernetes Package Manager
+# Helm Classic - A Kubernetes Package Manager
 
 |![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Helm Classic (the `helm/helm` repository) is **no longer actively developed** but will remain available until `kubernetes/helm` has stabilized.
 |---|---|

--- a/action/action.go
+++ b/action/action.go
@@ -19,7 +19,7 @@ func mustConfig(homedir string) *config.Configfile {
 	rpath := filepath.Join(homedir, helm.Configfile)
 	cfg, err := config.Load(rpath)
 	if err != nil {
-		log.Warn("Oops! Looks like we had some issues running your command! Running `helm doctor` to ensure we have all the necessary prerequisites in place...")
+		log.Warn("Oops! Looks like we had some issues running your command! Running `helmc doctor` to ensure we have all the necessary prerequisites in place...")
 		Doctor(homedir)
 		cfg, err = config.Load(rpath)
 		if err != nil {

--- a/action/doc.go
+++ b/action/doc.go
@@ -1,4 +1,4 @@
-// Package action provides implementations for each Helm command.
+// Package action provides implementations for each Helm Classic command.
 //
 // This is not intended to be a stand-alone library, as
 // many of the commands will write to output, and even os.Exit

--- a/action/doctor.go
+++ b/action/doctor.go
@@ -7,7 +7,7 @@ import (
 	helm "github.com/helm/helm-classic/util"
 )
 
-// Doctor helps you see what's wrong with your helm setup
+// Doctor helps you see what's wrong with your Helm Classic setup
 func Doctor(home string) {
 	log.Info("Checking things locally...")
 	CheckLocalPrereqs(home)
@@ -17,7 +17,7 @@ func Doctor(home string) {
 }
 
 // CheckAllPrereqs makes sure we have all the tools we need for overall
-// helm success
+// Helm Classic success
 func CheckAllPrereqs(home string) {
 	CheckLocalPrereqs(home)
 	CheckKubePrereqs()

--- a/action/edit.go
+++ b/action/edit.go
@@ -11,7 +11,7 @@ import (
 // Edit charts using the shell-defined $EDITOR
 //
 // - chartName being edited
-// - homeDir is the helm home directory for the user
+// - homeDir is the Helm Classic home directory for the user
 func Edit(chartName, homeDir string) {
 
 	chartDir := util.WorkspaceChartDirectory(homeDir, chartName)

--- a/action/fetch.go
+++ b/action/fetch.go
@@ -55,7 +55,7 @@ func fetch(chartName, lname, homedir, chartpath string) {
 
 	fi, err := os.Stat(src)
 	if err != nil {
-		log.Warn("Oops. Looks like there was an issue finding the chart, %s, in %s. Running `helm update` to ensure you have the latest version of all Charts from Github...", lname, src)
+		log.Warn("Oops. Looks like there was an issue finding the chart, %s, in %s. Running `helmc update` to ensure you have the latest version of all Charts from Github...", lname, src)
 		Update(homedir)
 		fi, err = os.Stat(src)
 		if err != nil {

--- a/action/update.go
+++ b/action/update.go
@@ -25,7 +25,7 @@ func Update(home string) {
 	log.Info("Done")
 }
 
-// CheckLatest checks whether this version of Helm is the latest version.
+// CheckLatest checks whether this version of Helm Classic is the latest version.
 //
 // This does not ensure that this is the latest. If a newer version is found,
 // this generates a message indicating that.
@@ -35,7 +35,7 @@ func Update(home string) {
 func CheckLatest(version string) {
 	ver, err := release.LatestVersion()
 	if err != nil {
-		log.Warn("Skipped Helm version check: %s", err)
+		log.Warn("Skipped Helm Classic version check: %s", err)
 		return
 	}
 
@@ -51,7 +51,7 @@ func CheckLatest(version string) {
 	}
 
 	if remote.GreaterThan(current) {
-		log.Warn("A new version of Helm is available. You have %s. The latest is %v", version, ver)
+		log.Warn("A new version of Helm Classic is available. You have %s. The latest is %v", version, ver)
 		log.Info("Download version %s by running: %s", ver, "curl -s https://get.helm.sh | bash")
 	}
 

--- a/action/update_test.go
+++ b/action/update_test.go
@@ -21,7 +21,7 @@ func TestCheckLatest(t *testing.T) {
 		CheckLatest("0.0.1")
 	})
 
-	test.ExpectContains(t, actual, "A new version of Helm")
+	test.ExpectContains(t, actual, "A new version of Helm Classic")
 }
 
 type MockGHRepoService struct {

--- a/cli/create.go
+++ b/cli/create.go
@@ -7,7 +7,7 @@ import (
 
 const createDescription = `This will scaffold a new chart named 'chart-name' in your
 local workdir. To edit the resulting chart, you may edit the files directly or
-use the 'helm edit' command.`
+use the 'helmc edit' command.`
 
 var createCmd = cli.Command{
 	Name:        "create",

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -6,7 +6,7 @@ import (
 )
 
 const doctorDescription = `This will run a series of checks to ensure that your
-experience with helm is trouble-free.`
+experience with helmc is trouble-free.`
 
 var doctorCmd = cli.Command{
 	Name:        "doctor",

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -6,7 +6,7 @@ import (
 )
 
 const editDescription = `Existing charts in the workspace can be edited using this command.
-'helm edit' will open all of the chart files in a single editor (as specified
+'helmc edit' will open all of the chart files in a single editor (as specified
 by the $EDITOR environment variable).`
 
 var editCmd = cli.Command{

--- a/cli/fetch.go
+++ b/cli/fetch.go
@@ -9,7 +9,7 @@ const fetchDescription = `Copy a chart from the Chart repository to a local work
 From this point, the copied chart may be safely modified to your needs.
 
 If an optional 'chart-name' is specified, the chart will be copied to a directory
-of that name. For example, 'helm fetch nginx www' will copy the the contents of
+of that name. For example, 'helmc fetch nginx www' will copy the the contents of
 the 'nginx' chart into a directory named 'www' in your workspace.`
 
 var fetchCmd = cli.Command{

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -7,11 +7,11 @@ import (
 
 var generateDesc = `Read a chart and generate manifests based on generator tools.
 
-'helm generate' reads all of the files in a chart, searching for a generation
+'helmc generate' reads all of the files in a chart, searching for a generation
 header. If it finds the header, it will execute the corresponding command.
 
 The header is in the form '#helm:generate CMD [ARGS]'. 'CMD' can be any command
-that Helm finds on $PATH. Optional 'ARGS' are arguments that will be passed on
+that Helm Classic finds on $PATH. Optional 'ARGS' are arguments that will be passed on
 to the command. Generator commands can begin with any of the following sequences:
 '#helm:generate', '//helm:generate', or '/*helm:generate'.
 
@@ -20,7 +20,10 @@ following:
 
 	#helm:generate helm tpl mytemplate.yaml
 
-If CMD is an absolute path, Helm will attempt to execute it even if it is not
+SPECIAL NOTE: For compatibility with older charts, Helm Classic will translate the 'helm' command
+used within any generator header to the equivalent 'helmc' command.
+
+If CMD is an absolute path, Helm Classic will attempt to execute it even if it is not
 on $PATH. Combined with the $HELM_GENERATE_DIR environment variable, charts can
 include their own local scripts:
 
@@ -30,24 +33,27 @@ Since '#' is a comment character in YAML, the YAML parser will ignore the
 generator line. But 'helm:generate' will read it as specifying that the following
 command should be run:
 
-	helm tpl mytemplate.yaml
+	helmc tpl mytemplate.yaml
 
-While the 'helm tpl' command can easily be used in conjunction with the
-'helm generate' command, you are not limited to just this tool. For example, one
+While the 'helmc tpl' command can easily be used in conjunction with the
+'helmc generate' command, you are not limited to just this tool. For example, one
 could run a sed substitution just as easily:
 
 	#helm:generate sed -i -e s|ubuntu-debootstrap|fluffy-bunny| my/pod.yaml
 
-Note that 'helm generate' does not execute inside of a shell. However, it does
+Note that 'helmc generate' does not execute inside of a shell. However, it does
 expand environment variables. The following variables are made available by the
-Helm system:
+Helm Classic system:
 
 - HELM_HOME: The Helm home directory
 - HELM_DEFAULT_REPO: The repository alias for the default repository.
 - HELM_GENERATE_FILE: The present file's name
 - HELM_GENERATE_DIR: The absolute path to the chart directory of the present chart
 
-By default, 'helm generate' will execute every generator that it finds in a
+SPECIAL NOTE: For compatibility with older charts, Helm Classic honors these old, "special"
+variables and does not replace them with 'HELMC_*' equivalents.
+
+By default, 'helmc generate' will execute every generator that it finds in a
 project. Generators can be mixed, with different files using different
 generators. The order of generation is the order in which the directory contents
 are listed.
@@ -57,7 +63,7 @@ The environment variables listed above are also available to generators.
 For charts that contain multiple different generator template sets, you may
 prevent generators from being run using the '--exclude' flag:
 
-	$ helm generate --exclude=tpl --exclude=sed foo
+	$ helmc generate --exclude=tpl --exclude=sed foo
 
 The above will prevent the generator from traversing the 'foo' chart's 'tpl/'
 or 'sed/' directories.

--- a/cli/helm.go
+++ b/cli/helm.go
@@ -15,21 +15,21 @@ import (
 // and should not be trusted.
 var version = "0.1.0"
 
-const globalUsage = `The Kubernetes package manager
+const globalUsage = `Helm Classic - A Kubernetes package manager
 
-To begin working with Helm, run the 'helm update' command:
+To begin working with Helm Classic, run the 'helmc update' command:
 
-$ helm update
+$ helmc update
 
 This will download all of the necessary data. Common actions from this point
 include:
 
-- helm help COMMAND: see help for a specific command
-- helm search: search for charts
-- helm fetch: make a local working copy of a chart
-- helm install: upload the chart to Kubernetes
+- helmc help COMMAND: see help for a specific command
+- helmc search: search for charts
+- helmc fetch: make a local working copy of a chart
+- helmc install: upload the chart to Kubernetes
 
-For more information on Helm, go to http://helm.sh.
+For more information on Helm Classic, go to http://helm.sh.
 
 ENVIRONMENT:
 $HELMC_HOME:     Set an alternative location for Helm files. By default, these
@@ -37,10 +37,10 @@ $HELMC_HOME:     Set an alternative location for Helm files. By default, these
 
 `
 
-// Cli is the main entrypoint for the Helm CLI.
+// Cli is the main entrypoint for the Helm Classic CLI.
 func Cli() *cli.App {
 	app := cli.NewApp()
-	app.Name = "helm"
+	app.Name = "helmc"
 	app.Usage = globalUsage
 	app.Version = version
 	app.EnableBashCompletion = true
@@ -55,7 +55,7 @@ func Cli() *cli.App {
 		cli.StringFlag{
 			Name:   "home",
 			Value:  "$HOME/.helmc",
-			Usage:  "The location of your Helm files",
+			Usage:  "The location of your Helm Classic files",
 			EnvVar: "HELMC_HOME",
 		},
 		cli.BoolFlag{

--- a/cli/home.go
+++ b/cli/home.go
@@ -7,7 +7,7 @@ import (
 
 var homeCmd = cli.Command{
 	Name:      "home",
-	Usage:     "Displays the location of the Helm home.",
+	Usage:     "Displays the location of the Helm Classic home.",
 	ArgsUsage: "",
 	Action: func(c *cli.Context) {
 		log.Msg(home(c))

--- a/cli/install.go
+++ b/cli/install.go
@@ -8,10 +8,10 @@ import (
 
 const installDescription = `If the given 'chart-name' is present in your workspace, it
 will be uploaded into Kubernetes. If no chart named 'chart-name' is found in
-your workspace, Helm will look for a chart with that name, install it into the
+your workspace, Helm Classic will look for a chart with that name, install it into the
 workspace, and then immediately upload it to Kubernetes.
 
-When multiple charts are specified, Helm will attempt to install all of them,
+When multiple charts are specified, Helm Classic will attempt to install all of them,
 following the resolution process described above.
 `
 

--- a/cli/lint_test.go
+++ b/cli/lint_test.go
@@ -15,7 +15,7 @@ func TestLintAllNone(t *testing.T) {
 	test.FakeUpdate(tmpHome)
 
 	output := test.CaptureOutput(func() {
-		Cli().Run([]string{"helm", "--home", tmpHome, "lint", "--all"})
+		Cli().Run([]string{"helmc", "--home", tmpHome, "lint", "--all"})
 	})
 
 	test.ExpectContains(t, output, fmt.Sprintf("Could not find any charts in \"%s", tmpHome))
@@ -29,7 +29,7 @@ func TestLintSingle(t *testing.T) {
 	action.Create(chartName, tmpHome)
 
 	output := test.CaptureOutput(func() {
-		Cli().Run([]string{"helm", "--home", tmpHome, "lint", chartName})
+		Cli().Run([]string{"helmc", "--home", tmpHome, "lint", chartName})
 	})
 
 	test.ExpectContains(t, output, fmt.Sprintf("Chart [%s] has passed all necessary checks", chartName))
@@ -43,7 +43,7 @@ func TestLintChartByPath(t *testing.T) {
 	action.Create(chartName, home1)
 
 	output := test.CaptureOutput(func() {
-		Cli().Run([]string{"helm", "--home", home2, "lint", util.WorkspaceChartDirectory(home1, chartName)})
+		Cli().Run([]string{"helmc", "--home", home2, "lint", util.WorkspaceChartDirectory(home1, chartName)})
 	})
 
 	test.ExpectContains(t, output, fmt.Sprintf("Chart [%s] has passed all necessary checks", chartName))
@@ -61,7 +61,7 @@ func TestLintAll(t *testing.T) {
 	action.Create("goodChart", tmpHome)
 
 	output := test.CaptureOutput(func() {
-		Cli().Run([]string{"helm", "--home", tmpHome, "lint", "--all"})
+		Cli().Run([]string{"helmc", "--home", tmpHome, "lint", "--all"})
 	})
 
 	test.ExpectMatches(t, output, "A README file was not found.*"+missingReadmeChart)

--- a/cli/template.go
+++ b/cli/template.go
@@ -9,19 +9,19 @@ import (
 const tplDescription = `Execute a template inside of a chart.
 
 This command is not intended to be run directly (though it can be). Instead, it
-is a helper for the generate command. Run 'helm help generate' for more.
+is a helper for the generate command. Run 'helmc help generate' for more.
 
-'helm template' provides a default implementation of a templating feature for
+'helmc template' provides a default implementation of a templating feature for
 Kubernetes manifests. Other more sophisticated methods can be plugged in using
-the 'helm generate' system.
+the 'helmc generate' system.
 
-'helm template' uses Go's built-in text template system to provide template
+'helmc template' uses Go's built-in text template system to provide template
 substitution inside of a chart. In addition to the built-in template commands,
-'helm template' supports all of the template functions provided by the Sprig
+'helmc template' supports all of the template functions provided by the Sprig
 library (https://github.com/Masterminds/sprig).
 
-If a values data file is provided, 'helm template' will use that as a source
-for values. If none is specified, only default values will be used. Helm uses
+If a values data file is provided, 'helmc template' will use that as a source
+for values. If none is specified, only default values will be used. Helm Classic uses
 simple extension scanning to determine the file type of the values data file.
 
 - YAML: .yaml, .yml
@@ -34,7 +34,7 @@ file instead of STDOUT. Writing to the source template file is unsupported.
 `
 
 // tplCmd is the command to handle templating.
-// helm tpl -o dest.txt -d data.toml my_template.tpl
+// helmc tpl -o dest.txt -d data.toml my_template.tpl
 var tplCmd = cli.Command{
 	Name:      "template",
 	Aliases:   []string{"tpl"},

--- a/cli/update.go
+++ b/cli/update.go
@@ -9,10 +9,10 @@ const updateDescription = `This will synchronize the local repository with the u
 The local cached copy is stored in '~/.helmc/cache' or (if specified)
 '$HELMC_HOME/cache'.
 
-The first time 'helm update' is run, the necessary directory structures are
+The first time 'helmc update' is run, the necessary directory structures are
 created and then the Git repository is pulled in full.
 
-Subsequent calls to 'helm update' will simply synchronize the local cache
+Subsequent calls to 'helmc update' will simply synchronize the local cache
 with the remote.`
 
 // updateCmd represents the CLI command for fetching the latest version of all charts from Github.
@@ -31,7 +31,7 @@ var updateCmd = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "no-version-check",
-			Usage: "Disable Helm's automatic check for newer versions of itself.",
+			Usage: "Disable Helm Classic's automatic check for newer versions of itself.",
 		},
 	},
 }

--- a/codec/object.go
+++ b/codec/object.go
@@ -57,7 +57,7 @@ func (m *Object) Ref() (*v1.ObjectReference, error) {
 // YAML takes the raw data and (re-)encodes it as YAML.
 func (m *Object) YAML() ([]byte, error) {
 	// We are not assuming that the m.data is YAML, though for the current
-	// iteration of Helm that assumption probably holds. Instead, we are
+	// iteration of Helm Classic that assumption probably holds. Instead, we are
 	// relying upon the decoder to decode to a generic format, and then we
 	// re-encode it into YAML.
 	var d interface{}

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 // ErrNotFound indicates no local repository could be found.
 var ErrNotFound = errors.New("No local repository")
 
-// Configfile is the top-level conifguration object for Helm.
+// Configfile is the top-level conifguration object for Helm Classic.
 type Configfile struct {
 	// filename may contain a reference back to the file that was read into
 	// this object.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Helm Classic: The Original Kubernetes Package Manager
+# Helm Classic: A Kubernetes Package Manager
 
 Helm Classic provides package management for Kubernetes. This directory provides
 a number of documents explaining how to build Helm Classic packages (called

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Helm Classic: The Original Kubernetes Package Manager
+# Helm Classic: A Kubernetes Package Manager
 
 [Helm Classic](https://helm.sh) helps you find and use software built for Kubernetes. The Helm Classic CLI uses Charts which not only contain metadata about software packages but also Pod, ReplicationController and Service manifests for Kubernetes. With a few Helm Classic commands you can quickly and easily deploy software packages like:
 

--- a/release/latest.go
+++ b/release/latest.go
@@ -8,7 +8,7 @@ import (
 var Owner = "helm"
 
 // Project is the default Helm repository name.
-var Project = "helm"
+var Project = "helm-classic"
 
 // RepoService is a GitHub client instance.
 var RepoService GHRepoService
@@ -18,7 +18,7 @@ type GHRepoService interface {
 	GetLatestRelease(string, string) (*github.RepositoryRelease, *github.Response, error)
 }
 
-// Latest returns information on the latest Helm version.
+// Latest returns information on the latest Helm Classic version.
 func Latest() (*github.RepositoryRelease, error) {
 	if RepoService == nil {
 		RepoService = github.NewClient(nil).Repositories

--- a/search/search.go
+++ b/search/search.go
@@ -1,4 +1,4 @@
-// Package search provides search features for Helm.
+// Package search provides search features for Helm Classic.
 package search
 
 import (

--- a/util/helm.go
+++ b/util/helm.go
@@ -9,10 +9,10 @@ import (
 	"github.com/helm/helm-classic/log"
 )
 
-// Configfile is the file containing helm's YAML configuration data.
+// Configfile is the file containing Helm Classic's YAML configuration data.
 const Configfile = "config.yaml"
 
-// DefaultConfigfile is the default Helm configuration.
+// DefaultConfigfile is the default Helm Classic configuration.
 const DefaultConfigfile = `repos:
   default: charts
   tables:


### PR DESCRIPTION
Fixes #469

This PR updates help, output messages, comments, and a few other errant, outdated occurrences of "helm" or "Helm" with "helmc" and "Helm Classic" wherever appropriate.