### PR TITLE
feat(manifest|action): handle "helm-keep" annotation

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -9,6 +9,10 @@ func (r TestRunner) ClusterInfo() ([]byte, error) {
 	return r.out, r.err
 }
 
+func (r TestRunner) Apply(stdin []byte, ns string) ([]byte, error) {
+	return r.out, r.err
+}
+
 func (r TestRunner) Create(stdin []byte, ns string) ([]byte, error) {
 	return r.out, r.err
 }

--- a/action/uninstall.go
+++ b/action/uninstall.go
@@ -127,6 +127,14 @@ func uninstallKind(kind []*manifest.Manifest, ns, ktype string, dry bool, client
 		if dry {
 			log.Msg("%s/%s", ktype, o.Name)
 		} else {
+			// If it's a keeper manifest, skip uninstall.
+			if data, err := o.VersionedObject.JSON(); err == nil {
+				if manifest.IsKeeper(data) {
+					log.Warn("Not uninstalling %s %s because of \"helm-keep\" annotation.\n"+
+						"---> Use kubectl to uninstall keeper manifests.\n", ktype, o.Name)
+					continue
+				}
+			}
 			out, err := client.Delete(o.Name, ktype, ns)
 			if err != nil {
 				log.Warn("Could not delete %s %s (Skipping): %s", ktype, o.Name, err)

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -35,6 +35,13 @@ func TestUninstall(t *testing.T) {
 				err: errors.New("oh snap"),
 			},
 		},
+		{
+			name:  "with a helmc annotation",
+			chart: "keep",
+			force: true,
+			expected: []string{"Running `kubectl delete` ...", "Not uninstalling",
+				"because of \"helm-keep\" annotation"},
+		},
 	}
 
 	tmpHome := test.CreateTmpHome()

--- a/docs/awesome.md
+++ b/docs/awesome.md
@@ -108,6 +108,31 @@ A good simple manifest typically includes:
 - A service definition for each backend service this chart relies upon (`foo-db-svc.yaml`)
 - A secrets file for each secret the RC uses (`foo-password-sec.yaml`)
 
+### Keeper Manifests
+
+To support upgrading between versions of a chart, Helm Classic allows individual manifests to be "keepers." These manifests get special treatment:
+
+- `helmc uninstall` skips them while printing a warning
+- `helmc install` applies changes rather than always creating a new manifest
+
+Marking a manifest as a keeper is accomplished by adding a `helm-keep: "true"` annotation:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+  annotations:
+    helm-keep: "true"
+```
+
+This mechanism allows essential pieces of infrastructure to remain in place while other components are uninstalled and reinstalled. For example, a chart might mark its `Namespace` and any externally visible `Service` manifests with `helm-keep`, to ensure that DNS entries aren't invalidated by destroying the `LoadBalancer` or `NodePort` ingress.
+
+The `helm-keep` annotation is respected by Helm Classic version 0.8.0 and later.
+
 ### Labels
 
 All Helm Classic charts should have an `app` label and a `heritage: helm` label in their metadata sections. These provide a base-level consistency across all Helm Classic charts. (`heritage: helm` makes it easy to search a Kubernetes cluster for all components installed via Helm Classic.)

--- a/kubectl/apply.go
+++ b/kubectl/apply.go
@@ -1,0 +1,29 @@
+package kubectl
+
+// Apply uploads a chart to Kubernetes
+func (r RealRunner) Apply(stdin []byte, ns string) ([]byte, error) {
+	args := []string{"apply", "-f", "-"}
+
+	if ns != "" {
+		args = append([]string{"--namespace=" + ns}, args...)
+	}
+
+	cmd := command(args...)
+	assignStdin(cmd, stdin)
+
+	return cmd.CombinedOutput()
+}
+
+// Apply returns the commands to kubectl
+func (r PrintRunner) Apply(stdin []byte, ns string) ([]byte, error) {
+	args := []string{"apply", "-f", "-"}
+
+	if ns != "" {
+		args = append([]string{"--namespace=" + ns}, args...)
+	}
+
+	cmd := command(args...)
+	assignStdin(cmd, stdin)
+
+	return []byte(cmd.String()), nil
+}

--- a/kubectl/apply_test.go
+++ b/kubectl/apply_test.go
@@ -1,0 +1,22 @@
+package kubectl
+
+import (
+	"testing"
+)
+
+func TestPrintApply(t *testing.T) {
+	var client Runner = PrintRunner{}
+
+	expected := `[CMD] kubectl --namespace=default-namespace apply -f - < some stdin data`
+
+	out, err := client.Apply([]byte("some stdin data"), "default-namespace")
+	if err != nil {
+		t.Error(err)
+	}
+
+	actual := string(out)
+
+	if expected != actual {
+		t.Fatalf("actual %s != expected %s", actual, expected)
+	}
+}

--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -7,6 +7,8 @@ var Path = "kubectl"
 type Runner interface {
 	// ClusterInfo returns Kubernetes cluster info
 	ClusterInfo() ([]byte, error)
+	// Apply updates or uploads a chart to Kubernetes
+	Apply([]byte, string) ([]byte, error)
 	// Create uploads a chart to Kubernetes
 	Create([]byte, string) ([]byte, error)
 	// Delete removes a chart from Kubernetes.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/helm/helm-classic/codec"
 	"github.com/helm/helm-classic/log"
@@ -123,4 +124,11 @@ func ParseDir(chartDir string) ([]*Manifest, error) {
 	}
 
 	return files, filepath.Walk(dir, walker)
+}
+
+// IsKeeper returns true if a manifest has a "helm-keep": "true" annotation.
+func IsKeeper(data []byte) bool {
+	// Look for ("helm-keep": "true") up to 10 lines after ("annotations:").
+	var keep = regexp.MustCompile(`\"annotations\":\s+\{(\n.*){0,10}\"helm-keep\":\s+\"true\"`)
+	return keep.Match(data)
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,11 +1,14 @@
 package manifest
 
 import (
+	"io/ioutil"
 	"strings"
 	"testing"
 )
 
 var testchart = "../testdata/charts/kitchensink"
+var testPlainManifest = "../testdata/service.json"
+var testKeeperManifest = "../testdata/service-keep.json"
 
 func TestFiles(t *testing.T) {
 	fs, err := Files(testchart)
@@ -66,5 +69,25 @@ func TestParseDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "malformed.yaml") {
 		t.Errorf("Failed to identify which manifest failed to be parsed. Got %s", err)
+	}
+}
+
+func TestIsKeeper(t *testing.T) {
+	// test that an ordinary JSON manifest doesn't look like a keeper
+	data, err := ioutil.ReadFile(testPlainManifest)
+	if err != nil {
+		t.Error(err)
+	}
+	if IsKeeper(data) {
+		t.Errorf("Expected false for %s", testPlainManifest)
+	}
+
+	// test that a keeper JSON manifest is detected
+	data, err = ioutil.ReadFile(testKeeperManifest)
+	if err != nil {
+		t.Error(err)
+	}
+	if !IsKeeper(data) {
+		t.Errorf("Expected true for %s", testKeeperManifest)
 	}
 }

--- a/testdata/charts/keep/Chart.yaml
+++ b/testdata/charts/keep/Chart.yaml
@@ -1,0 +1,10 @@
+name: keep
+home: https://github.com/helm/helm-classic
+version: 0.0.1
+description: Namespace manifest with keeper annotation.
+maintainers:
+- Deis Team <engineering@deis.com>
+details: |-
+  This package provides a Kubernetes namespace manifest with a "helm-keep" annotation that marks
+  it for special install and uninstall handling.
+  Helm Classic v0.8.0 or later is required to use this chart.

--- a/testdata/charts/keep/manifests/keep-ns.yaml
+++ b/testdata/charts/keep/manifests/keep-ns.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keep
+  labels:
+    name: keep
+  annotations:
+    helm-keep: "true"

--- a/testdata/service-keep.json
+++ b/testdata/service-keep.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "example-todo",
+    "labels": {
+      "heritage": "deis"
+    },
+    "annotations": {
+      "helm-keep": "true"
+    }
+  },
+  "spec": {
+    "type": "NodePort",
+    "ports": [
+      {
+        "port": 3000,
+        "nodePort": 30000,
+        "name": "http",
+        "protocol": "TCP"
+      }
+    ],
+    "selector": {
+      "name": "example-todo"
+    }
+  }
+}

--- a/testdata/service.json
+++ b/testdata/service.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "example-todo",
+    "labels": {
+      "heritage": "deis"
+    },
+    "annotations": {
+      "helm-bleep": "true"
+    }
+  },
+  "spec": {
+    "type": "NodePort",
+    "ports": [
+      {
+        "port": 3000,
+        "nodePort": 30000,
+        "name": "http",
+        "protocol": "TCP"
+      }
+    ],
+    "selector": {
+      "name": "example-todo"
+    }
+  }
+}


### PR DESCRIPTION
This modifies `helmc` to treat manifests with a `helm-keep: "true"` annotation specially:
- On `install`, they are treated with `kubectl apply` rather than `kubectl create`
- On `uninstall`, they are skipped with a warning

This behavior should allow crucial manifests to persist over a `helmc uninstall <version_one> && helmc install <version_two>` upgrade scenario. In particular, an externally routed service can be annotated with `helm-keep` so that DNS does not have to be recreated for its `LoadBalancer`.

Closes #465.