### PR TITLE
fix(install): let VersionedObject marshal its own JSON

### DIFF
--- a/action/remove_test.go
+++ b/action/remove_test.go
@@ -27,7 +27,7 @@ func TestTRemove(t *testing.T) {
 		{"kitchensink", mockNotFoundGetter, false, "All clear! You have successfully removed kitchensink from your workspace."},
 
 		// when manifests are installed
-		{"kitchensink", mockFoundGetter, false, "Found 10 installed manifests for kitchensink.  To remove a chart that has been installed the --force flag must be set."},
+		{"kitchensink", mockFoundGetter, false, "Found 11 installed manifests for kitchensink.  To remove a chart that has been installed the --force flag must be set."},
 
 		// when manifests are installed and force is set
 		{"kitchensink", mockNotFoundGetter, true, "All clear! You have successfully removed kitchensink from your workspace."},

--- a/testdata/charts/kitchensink/manifests/sink-limits.yaml
+++ b/testdata/charts/kitchensink/manifests/sink-limits.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: kitchensink-limits
+  namespace: kitchensink
+spec:
+  limits:
+  - default:
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 250m
+      memory: 500Mi
+    type: Container


### PR DESCRIPTION
The marshalAndCreate method was always returning empty JSON for unknown manifest types.

Fixes #477.