### PR TITLE
feat(action): add ConfigMap install ordering

### DIFF
--- a/action/install.go
+++ b/action/install.go
@@ -15,14 +15,14 @@ import (
 //
 // Anything not on the list will be installed after the last listed item, in
 // an indeterminate order.
-var InstallOrder = []string{"Namespace", "Secret", "PersistentVolume", "ServiceAccount", "Service", "Pod", "ReplicationController", "Deployment", "DaemonSet", "Ingress", "Job"}
+var InstallOrder = []string{"Namespace", "Secret", "ConfigMap", "PersistentVolume", "ServiceAccount", "Service", "Pod", "ReplicationController", "Deployment", "DaemonSet", "Ingress", "Job"}
 
 // UninstallOrder defines the order in which manifests are uninstalled.
 //
 // Unknown manifest types (those not explicitly referenced in this list) will
 // be uninstalled before any of these, since we know that none of the core
 // types depend on non-core types.
-var UninstallOrder = []string{"Service", "Pod", "ReplicationController", "Deployment", "DaemonSet", "Secret", "PersistentVolume", "ServiceAccount", "Ingress", "Job", "Namespace"}
+var UninstallOrder = []string{"Service", "Pod", "ReplicationController", "Deployment", "DaemonSet", "ConfigMap", "Secret", "PersistentVolume", "ServiceAccount", "Ingress", "Job", "Namespace"}
 
 // Install loads a chart into Kubernetes.
 //

--- a/action/remove_test.go
+++ b/action/remove_test.go
@@ -27,7 +27,7 @@ func TestTRemove(t *testing.T) {
 		{"kitchensink", mockNotFoundGetter, false, "All clear! You have successfully removed kitchensink from your workspace."},
 
 		// when manifests are installed
-		{"kitchensink", mockFoundGetter, false, "Found 11 installed manifests for kitchensink.  To remove a chart that has been installed the --force flag must be set."},
+		{"kitchensink", mockFoundGetter, false, "Found 12 installed manifests for kitchensink.  To remove a chart that has been installed the --force flag must be set."},
 
 		// when manifests are installed and force is set
 		{"kitchensink", mockNotFoundGetter, true, "All clear! You have successfully removed kitchensink from your workspace."},

--- a/chart/chart_test.go
+++ b/chart/chart_test.go
@@ -1,14 +1,13 @@
 package chart
 
-import (
-	"testing"
-)
+import "testing"
 
 const testfile = "../testdata/test-Chart.yaml"
 const testchart = "../testdata/charts/kitchensink"
 
 func TestLoad(t *testing.T) {
 	c, err := Load(testchart)
+
 	if err != nil {
 		t.Errorf("Failed to load chart: %s", err)
 	}
@@ -28,19 +27,25 @@ func TestLoad(t *testing.T) {
 	if len(c.Kind["ReplicationController"]) == 0 {
 		t.Error("No RCs found")
 	}
+
 	if len(c.Kind["Deployment"]) == 0 {
 		t.Error("No Deployments found")
 	}
+
 	if len(c.Kind["Namespace"]) == 0 {
-		t.Errorf("No namespaces found")
+		t.Error("No Namespaces found")
 	}
 
 	if len(c.Kind["Secret"]) == 0 {
 		t.Error("Is it secret? Is it safe? NO!")
 	}
 
+	if len(c.Kind["ConfigMap"]) == 0 {
+		t.Error("No ConfigMaps found.")
+	}
+
 	if len(c.Kind["PersistentVolume"]) == 0 {
-		t.Errorf("No volumes.")
+		t.Error("No volumes.")
 	}
 
 	if len(c.Kind["Service"]) == 0 {

--- a/codec/object.go
+++ b/codec/object.go
@@ -222,6 +222,12 @@ func (m *Object) Ingress() (*v1beta1.Ingress, error) {
 	return o, m.Object(o)
 }
 
+// ConfigMap decodes a manifest into a ConfigMap.
+func (m *Object) ConfigMap() (*v1.ConfigMap, error) {
+	o := new(v1.ConfigMap)
+	return o, m.Object(o)
+}
+
 // Deployment decodes a manifest into a Deployment.
 func (m *Object) Deployment() (*v1beta1.Deployment, error) {
 	o := new(v1beta1.Deployment)

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,11 @@
-hash: 2839ac00b6126dd58c0b93de42a4386b9c6ab1a3157481900c3556abf6195f76
-updated: 2016-05-23T16:56:31.611828548-06:00
+hash: e3b30639ce08a893ef3809167f67c665ac85c03ed1611c15721b8fb7fbcc1b64
+updated: 2016-05-31T16:45:05.345758638-06:00
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
 - name: code.google.com/p/goprotobuf
-  version: e51d002c610dbe8c136679a67a6ded5df4d49b5c
+  version: 9e6977f30c91c78396e719e164e57f9287fff42c
   repo: https://github.com/golang/protobuf
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
-- name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
-  subpackages:
-  - quantile
 - name: github.com/BurntSushi/toml
   version: f0aeabca5a127c4078abb8c8d64298b147264b55
 - name: github.com/cloudfoundry-incubator/candiedyaml
@@ -27,7 +21,7 @@ imports:
   subpackages:
   - prettyprint
 - name: github.com/docker/docker
-  version: 2b27fe17a1b3fb8472fde96d768fa70996adf201
+  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
   subpackages:
   - pkg/jsonmessage
   - pkg/mount
@@ -36,21 +30,12 @@ imports:
   - pkg/term
   - pkg/timeutils
   - pkg/units
-- name: github.com/docker/libcontainer
-  version: 5dc7ba0f24332273461e45bc49edcb4d5aa6c44c
-  subpackages:
-  - cgroups/fs
-  - configs
-  - cgroups
-  - system
+- name: github.com/docker/go-units
+  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
 - name: github.com/ghodss/yaml
   version: e8e0db9016175449df0e9c4b6e6995a9433a395c
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/protobuf
-  version: 7f07925444bb51fa4cf9dfe6f7661876f8852275
-  subpackages:
-  - proto
 - name: github.com/google/go-github
   version: 81d0490d8aa8400f6760a077f4a2039eb0296e86
   subpackages:
@@ -62,39 +47,32 @@ imports:
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/juju/ratelimit
-  version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/Masterminds/semver
   version: 808ed7761c233af2de3f9729a041d68c62527f3a
 - name: github.com/Masterminds/sprig
   version: e6494bc7e81206ba6db404d2fd96500ffc453407
 - name: github.com/Masterminds/vcs
   version: 7af28b64c5ec41b1558f5514fd938379822c237c
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+- name: github.com/opencontainers/runc
+  version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
   subpackages:
-  - pbutil
+  - libcontainer
+  - libcontainer/cgroups/fs
+  - libcontainer/configs
+  - libcontainer/cgroups
+  - libcontainer/system
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
-- name: github.com/prometheus/client_golang
-  version: 3b78d7a77f51ccbc364d4bc170920153022cfd08
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: ef7a9a5fb138aa5d3a19988537606226869a0390
-  subpackages:
-  - expfmt
-  - model
-- name: github.com/prometheus/procfs
-  version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/spf13/pflag
-  version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/steveeJ/gexpect
   version: ca42424d18c76d0d51a4cccd830d11878e9e5c17
   repo: https://github.com/coreos/gexpect
+- name: github.com/ugorji/go
+  version: f4485b318aadd133842532f841dc205a8e339d74
+  subpackages:
+  - codec
 - name: golang.org/x/crypto
   version: 5bcd134fee4dd1475da17714aac19c0aa0142e2f
   subpackages:
@@ -103,20 +81,20 @@ imports:
   - curve25519
   - nacl/secretbox
   - salsa20/salsa
-  - ssh
   - poly1305
-  - ed25519
-  - ed25519/internal/edwards25519
 - name: golang.org/x/net
   version: c2528b2dd8352441850638a8bb678c2ad056fd3e
   subpackages:
   - context
   - html
+  - http2
+  - internal/timeseries
+  - trace
   - websocket
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: k8s.io/kubernetes
-  version: 92635e23dfafb2ddc828c8ac6c03c7a7205a84d8
+  version: 3eed1e3be6848b877ff80a93da3785d9034d0a4f
   subpackages:
   - pkg
   - pkg/api
@@ -130,18 +108,25 @@ imports:
   - pkg/fields
   - pkg/labels
   - pkg/runtime
+  - pkg/runtime/serializer
   - pkg/types
   - pkg/util
+  - pkg/util/intstr
   - pkg/util/rand
   - pkg/util/sets
-  - pkg/api/registered
+  - pkg/util/parsers
   - pkg/apis/extensions
-  - third_party/forked/reflect
-  - pkg/util/fielderrors
-  - pkg/util/validation
-  - pkg/util/yaml
-  - pkg/api/util
   - pkg/util/errors
+  - third_party/forked/reflect
+  - pkg/util/validation
+  - pkg/conversion/queryparams
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/versioning
+  - pkg/util/integer
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/util/runtime
 - name: launchpad.net/gocheck
   version: 4f90aeace3a26ad7021961c297b22c42160c7b25
   repo: https://github.com/go-check/check

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/Masterminds/semver
   version: ^1.1.0
 - package: k8s.io/kubernetes
-  version: v1.1.1
+  version: v1.2.4
   subpackages:
   - pkg
 - package: speter.net/go/exp/math/dec/inf

--- a/testdata/charts/kitchensink/manifests/sink-configmap.yaml
+++ b/testdata/charts/kitchensink/manifests/sink-configmap.yaml
@@ -1,0 +1,17 @@
+#helm:generate helm tpl -d values.toml -o manifests/drone-configmap.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-03-30T21:14:38Z
+  name: drone
+  namespace: default
+data:
+  caddy.conf: |-
+    tls replace@me.com
+    drone.testing.com {
+        proxy / drone:80 {
+          proxy_header X-Forwarded-Proto {scheme}
+          proxy_header X-Forwarded-For {host}
+          proxy_header Host {host}
+        }
+    }


### PR DESCRIPTION
Also updates the k8s `glide` dependency to 1.2.4 so `v1.ConfigMap` is visible.

Closes #461.

See also #462.