### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export GO15VENDOREXPERIMENT=1
-
 REPO_PATH := github.com/helm/helm-classic
 
 # The following variables describe the containerized development environment
@@ -12,7 +10,7 @@ HELM_BIN := ${BIN_DIR}/helmc
 
 VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null)+$(shell git rev-parse --short HEAD)
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.12.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
Includes the go 1.7 toolchain. See https://tip.golang.org/doc/go1.7

I've been testing macOS Sierra developer betas, and both compiling and running `helmc` caused frequent panics until I started using go 1.7. So this should be some future-proofing for good ol' Helm classic.